### PR TITLE
fix: install crashpad when running `cmake --install`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
 ## Unreleased
+
+- Dev: `crashpad-handler` is now installed when running `cmake --install` (into `<prefix-dir>/crashpad/`). (#14)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set_target_properties(${PROJECT_NAME}
         OUTPUT_NAME "crashpad-handler"
         CXX_STANDARD 20
 )
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION chrashpad)
 
 if(WIN32)
     target_compile_definitions(${PROJECT_LIB} PUBLIC NOMINMAX WIN32_LEAN_AND_MEAN)


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Previously crashpad wasn't installed, this fixes it. Crashpad is installed in `<install-prefix-path>/crashpad`.