### PR TITLE
feat: build with clang-cl too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    name: "Build on ${{ matrix.os }}"
+    name: "Build on ${{ matrix.os }} with ${{matrix.compiler}}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
         if: startsWith(matrix.os, 'windows') && matrix.compiler == 'clang-cl'
         uses: KyleMayes/install-llvm-action@v2
         with:
-          version: 19
+          version: '19.1'
           env: true
 
       - name: Build (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2.0.6
         with:
           version: 19
-      
+
       - name: Set compiler to clang-cl
         if: startsWith(matrix.os, 'windows') && matrix.compiler == 'clang-cl'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
+        compiler: [cl, clang-cl]
 
       fail-fast: false
 
@@ -32,6 +33,13 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: ilammy/msvc-dev-cmd@v1.13.0
 
+      - name: Install LLVM and Clang
+        if: startsWith(matrix.os, 'windows') && matrix.compiler == 'clang-cl'
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: 19
+          env: true
+
       - name: Build (Windows)
         if: startsWith(matrix.os, 'windows')
         shell: pwsh
@@ -40,7 +48,7 @@ jobs:
           ninja -C build
 
       - name: Upload artifact (Windows)
-        if: startsWith(matrix.os, 'windows')
+        if: startsWith(matrix.os, 'windows') && matrix.compiler == 'cl'
         uses: actions/upload-artifact@v4
         with:
           name: crashpad-handler.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,11 @@ jobs:
         uses: KyleMayes/install-llvm-action@v2.0.6
         with:
           version: 19
-          env: true
+      
+      - name: Set compiler to clang-cl
+        run: |
+          echo "CC=clang-cl" >> "$Env:GITHUB_ENV"
+          echo "CXX=clang-cl" >> "$Env:GITHUB_ENV"
 
       - name: Build (Windows)
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,9 +35,9 @@ jobs:
 
       - name: Install LLVM and Clang
         if: startsWith(matrix.os, 'windows') && matrix.compiler == 'clang-cl'
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.6
         with:
-          version: '19.1'
+          version: 19
           env: true
 
       - name: Build (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
           version: 19
       
       - name: Set compiler to clang-cl
+        if: startsWith(matrix.os, 'windows') && matrix.compiler == 'clang-cl'
         run: |
           echo "CC=clang-cl" >> "$Env:GITHUB_ENV"
           echo "CXX=clang-cl" >> "$Env:GITHUB_ENV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 
 - Dev: `crashpad-handler` is now installed when running `cmake --install` (into `<prefix-dir>/crashpad/`). (#14)
+- Dev: Added support and CI for building with `clang-cl`. (#61)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(${PROJECT_LIB}
     PUBLIC
         crashpad_handler_lib
         crashpad_tools
+        crashpad_interface # inherit warning levels ("as if" we were a crashpad lib)
         magic_enum::magic_enum
 )
 target_include_directories(${PROJECT_LIB} PUBLIC "${CMAKE_CURRENT_LIST_DIR}/src")


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Sentry's fork of crashpad now supports `clang-cl` as an alternative to MSVC's `cl`. This project is the last dependency of Chatterino, that couldn't be built with `clang-cl`. The release will still use the MSVC artifact - this PR only makes sure we can build with `clang-cl`.