### PR TITLE
bump clang-cl version from 19 to 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         if: startsWith(matrix.os, 'windows') && matrix.compiler == 'clang-cl'
         uses: KyleMayes/install-llvm-action@v2.0.9
         with:
-          version: 19
+          version: 20
 
       - name: Set compiler to clang-cl
         if: startsWith(matrix.os, 'windows') && matrix.compiler == 'clang-cl'


### PR DESCRIPTION
Seems like clang 20 is required as of some time ago - see https://github.com/Chatterino/crash-handler/actions/runs/27449595186/job/81141905609

```
C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Tools\MSVC\14.51.36231\include\yvals_core.h(533,58): note: expanded from macro '_EMIT_STL_ERROR'
  533 | #define _EMIT_STL_ERROR(NUMBER, MESSAGE)   static_assert(false, "error " #NUMBER ": " MESSAGE)
      |                                                          ^~~~~
1 error generated.
```